### PR TITLE
Extend utdataavgransning

### DIFF
--- a/camel-ladok3-component/pom.xml
+++ b/camel-ladok3-component/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>ladok3</artifactId>
     <groupId>se.kth.infosys.smx.ladok3</groupId>
-    <version>1.50.7</version>
+    <version>1.50.8</version>
   </parent>
 
   <artifactId>camel-ladok3-component</artifactId>

--- a/camel-ladok3-test-utils/pom.xml
+++ b/camel-ladok3-test-utils/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>se.kth.infosys.smx.ladok3</groupId>
     <artifactId>ladok3</artifactId>
-    <version>1.50.7</version>
+    <version>1.50.8</version>
   </parent>
   <artifactId>camel-ladok3-test-utils</artifactId>
   <name>Camel Ladok3 test utilities</name>

--- a/ladok3-model/pom.xml
+++ b/ladok3-model/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>se.kth.infosys.smx.ladok3</groupId>
     <artifactId>ladok3</artifactId>
-    <version>1.50.7</version>
+    <version>1.50.8</version>
   </parent>
 
   <artifactId>ladok3-model</artifactId>

--- a/ladok3-rest/pom.xml
+++ b/ladok3-rest/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>se.kth.infosys.smx.ladok3</groupId>
     <artifactId>ladok3</artifactId>
-    <version>1.50.7</version>
+    <version>1.50.8</version>
   </parent>
 
   <artifactId>ladok3-rest</artifactId>

--- a/ladok3-rest/src/main/java/se/kth/infosys/ladok3/StudiedeltagandeServiceImpl.java
+++ b/ladok3-rest/src/main/java/se/kth/infosys/ladok3/StudiedeltagandeServiceImpl.java
@@ -144,6 +144,13 @@ public class StudiedeltagandeServiceImpl extends AbstractLadok3Service implement
           typ.getUtdataAvgransningsvarden().add((String)params.get("utbildningstypsgrupper"));
           fraga.getUtdataAvgransningar().getUtdataAvgransningar().getUtdataAvgransning().add(typ);
         }
+        
+        if(params.get("dokumenteradaktivitet") != null) {
+          UtdataAvgransning aktivitet = new UtdataAvgransning();
+          aktivitet.setUtdataAvgransningstyp(UtdataAvgransningstyp.DOKUMENTERADAKTIVITET);
+          aktivitet.getUtdataAvgransningsvarden().add((String)params.get("dokumenteradaktivitet"));
+          fraga.getUtdataAvgransningar().getUtdataAvgransningar().getUtdataAvgransning().add(aktivitet);
+        }
       }
       return fraga;
     }

--- a/ladok3-rest/src/main/java/se/kth/infosys/ladok3/StudiedeltagandeServiceImpl.java
+++ b/ladok3-rest/src/main/java/se/kth/infosys/ladok3/StudiedeltagandeServiceImpl.java
@@ -132,23 +132,27 @@ public class StudiedeltagandeServiceImpl extends AbstractLadok3Service implement
         }
         fraga.setSidstorlek(limit);
 
-        if(params.get("datumperiod") != null) {
+        final String datumPeriod = (String) params.get("datumperiod");
+        if(datumPeriod != null) {
           UtdataAvgransning datum = new UtdataAvgransning();
           datum.setUtdataAvgransningstyp(UtdataAvgransningstyp.REGISTRERING_ELLER_AKTIVITET_INOM);
-          datum.getUtdataAvgransningsvarden().add((String)params.get("datumperiod"));
+          datum.getUtdataAvgransningsvarden().add(datumPeriod);
           fraga.getUtdataAvgransningar().getUtdataAvgransningar().getUtdataAvgransning().add(datum);
         }
-        if(params.get("utbildningstypsgrupper") != null) {
+
+        final String utbildningsTypsGrupper = (String) params.get("utbildningstypsgrupper");
+        if(utbildningsTypsGrupper != null) {
           UtdataAvgransning typ = new UtdataAvgransning();
           typ.setUtdataAvgransningstyp(UtdataAvgransningstyp.UTBILDNINGSTYPSGRUPPER);
-          typ.getUtdataAvgransningsvarden().add((String)params.get("utbildningstypsgrupper"));
+          typ.getUtdataAvgransningsvarden().add(utbildningsTypsGrupper);
           fraga.getUtdataAvgransningar().getUtdataAvgransningar().getUtdataAvgransning().add(typ);
         }
-        
-        if(params.get("dokumenteradaktivitet") != null) {
+
+        final String dokumenteradAktivitet = (String) params.get("dokumenteradaktivitet");
+        if(dokumenteradAktivitet != null) {
           UtdataAvgransning aktivitet = new UtdataAvgransning();
           aktivitet.setUtdataAvgransningstyp(UtdataAvgransningstyp.DOKUMENTERADAKTIVITET);
-          aktivitet.getUtdataAvgransningsvarden().add((String)params.get("dokumenteradaktivitet"));
+          aktivitet.getUtdataAvgransningsvarden().add(dokumenteradAktivitet);
           fraga.getUtdataAvgransningar().getUtdataAvgransningar().getUtdataAvgransning().add(aktivitet);
         }
       }

--- a/ladok3-rest/src/main/java/se/kth/infosys/ladok3/utdata/StudieaktivitetOchFinansiering.java
+++ b/ladok3-rest/src/main/java/se/kth/infosys/ladok3/utdata/StudieaktivitetOchFinansiering.java
@@ -41,7 +41,7 @@ public class StudieaktivitetOchFinansiering {
     studieaktivitetProcent = next.getVarden().get(10);
     studiefinansieringProcent = next.getVarden().get(11);
     studiefinansieringKod = next.getVarden().size() > 12 ? next.getVarden().get(12) : "";
-    studiefinansieringBenamning = next.getVarden().size() > 12 ? next.getVarden().get(13) : "";
+    studiefinansieringBenamning = next.getVarden().size() > 13 ? next.getVarden().get(13) : "";
   }
 
   public String getUid() {

--- a/ladok3-rest/src/main/java/se/kth/infosys/ladok3/utdata/StudieaktivitetOchFinansiering.java
+++ b/ladok3-rest/src/main/java/se/kth/infosys/ladok3/utdata/StudieaktivitetOchFinansiering.java
@@ -40,8 +40,8 @@ public class StudieaktivitetOchFinansiering {
     studieaktivitetPeriod = next.getVarden().get(9);
     studieaktivitetProcent = next.getVarden().get(10);
     studiefinansieringProcent = next.getVarden().get(11);
-    studiefinansieringKod = next.getVarden().get(12);
-    studiefinansieringBenamning = next.getVarden().get(13);
+    studiefinansieringKod = next.getVarden().size() > 12 ? next.getVarden().get(12) : "";
+    studiefinansieringBenamning = next.getVarden().size() > 12 ? next.getVarden().get(13) : "";
   }
 
   public String getUid() {

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>se.kth.infosys.smx.ladok3</groupId>
   <artifactId>ladok3</artifactId>
-  <version>1.50.7</version>
+  <version>1.50.8</version>
   <packaging>pom</packaging>
 
   <name>KTH Ladok3 Integration</name>
@@ -125,6 +125,7 @@
         <configuration>
           <outputDirectory>dependency-check</outputDirectory>
           <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
+          <failOnError>false</failOnError>
 	      <suppressionFiles>
             <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
           </suppressionFiles>


### PR DESCRIPTION
Extended the Utdatafraga in StudieaktivitetOchFinansiering to included the ability to filter on only students with activity this period. Usefull when you want to limit the amount of traffic agains Ladok and gives you faster response time. 